### PR TITLE
fix: rename sqs url env variable name

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -1,5 +1,5 @@
 exports.connectionString = process.env.DATABASE_URL
-exports.queueUrl = process.env.SQS_QUEUE_URL
+exports.queueUrl = process.env.SQS_URL
 exports.awsconfig = { 
     "accessKeyId": process.env.AWS_ACCESS_KEY_ID,
     "secretAccessKey": process.env.AWS_ACCESS_KEY,


### PR DESCRIPTION
Fix to rename the sqs url environment variable name.